### PR TITLE
Make the date look better

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Build ISO
         run: |
-          export RELEASE_TAG=$(date +"%Y%m%d%H%M")
+          export RELEASE_TAG=$(date +%d-%m-%Y)
           echo "RELEASE_TAG=$RELEASE_TAG" >> $GITHUB_ENV
           image=$(guix system image -t iso9660 installer.scm)
           cp $image ./guix-installer-$RELEASE_TAG.iso


### PR DESCRIPTION
The date that is there while it does the job isnt  very nice to the eye.
I changed the syntax of it to be better 
it would be guix-installer-31-05-2021.iso
instead of guix-installer-202105302146.iso
