### PR TITLE
Bump git checkout actions to v4

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -16,6 +16,11 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+      - name: Check network
+        run: |
+          # output network settings to debug
+          ip a
+          
       - name: Git checkout
         uses: actions/checkout@v4
 
@@ -23,10 +28,7 @@ jobs:
         uses: PromyLOPh/guix-install-action@v1.5
 
       - name: Build ISO
-        run: |
-          # output network settings to debug 
-          ip a
-          
+        run: |          
           # Write out the channels file so it can be included
           guix time-machine -C './guix/base-channels.scm' -- describe -f channels > './guix/channels.scm'
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -23,7 +23,10 @@ jobs:
         uses: PromyLOPh/guix-install-action@v1.5
 
       - name: Build ISO
-        run: |       
+        run: |
+          # output network settings to debug 
+          ip a
+          
           # Write out the channels file so it can be included
           guix time-machine -C './guix/base-channels.scm' -- describe -f channels > './guix/channels.scm'
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -24,6 +24,9 @@ jobs:
 
       - name: Build ISO
         run: |
+          # Test MTU settings
+          ip a
+          
           # Write out the channels file so it can be included
           guix time-machine -C './guix/base-channels.scm' -- describe -f channels > './guix/channels.scm'
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Git checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Install Guix
         uses: PromyLOPh/guix-install-action@v1.5

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -23,10 +23,7 @@ jobs:
         uses: PromyLOPh/guix-install-action@v1.5
 
       - name: Build ISO
-        run: |
-          # Test MTU settings
-          sudo ip a
-          
+        run: |       
           # Write out the channels file so it can be included
           guix time-machine -C './guix/base-channels.scm' -- describe -f channels > './guix/channels.scm'
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -25,7 +25,7 @@ jobs:
       - name: Build ISO
         run: |
           # Test MTU settings
-          ip a
+          sudo ip a
           
           # Write out the channels file so it can be included
           guix time-machine -C './guix/base-channels.scm' -- describe -f channels > './guix/channels.scm'


### PR DESCRIPTION
Update git checkout actions from v2 to the latest version to silence node depreciation warnings. 