### PR TITLE
Bump checkout action - v2 to v4

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Git checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Install Guix
         uses: PromyLOPh/guix-install-action@v1.5


### PR DESCRIPTION
Update github checkout action to silence node depreciation warnings