### PR TITLE
Workaround 2Gib file size limit by using compression and `split`

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -93,4 +93,4 @@ jobs:
           files: guix-installer-${{ env.RELEASE_TAG }}.tar.gz-part-*
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITHUB_REPOSITORY: SohamG/guix-installer
+          GITHUB_REPOSITORY: SystemCrafters/guix-installer

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -59,7 +59,7 @@ jobs:
     
       - name: Build ISO
         run: |
-          
+          guix install nss-certs
           # Write out the channels file so it can be included
           guix time-machine -C ./guix/base-channels.scm -- describe -f channels > ./guix/channels.scm
           

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -93,4 +93,4 @@ jobs:
           files: guix-installer-${{ env.RELEASE_TAG }}.tar.gz-part-*
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITHUB_REPOSITORY: SystemCrafters/guix-installer
+          GITHUB_REPOSITORY: SohamG/guix-installer

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -70,8 +70,17 @@ jobs:
           export RELEASE_TAG=$(date +"%Y%m%d%H%M")
           echo "RELEASE_TAG=$RELEASE_TAG" >> $GITHUB_ENV
           cp $image ./guix-installer-$RELEASE_TAG.iso
+          # Compress image in tar achirve
           tar czvf guix-installer-$RELEASE_TAG.tar.gz ./guix-installer-$RELEASE_TAG.iso
-          split -b 2GiB ./guix-installer-$RELEASE_TAG.tar.gz "guix-installer-$RELEASE_TAG.tar.gz-part-"
+          # Github limits single files to 2GiB in releases.
+          IMAGE_SIZE=$(stat -c %s ./guix-installer-$RELEASE_TAG.tar.gz)
+          mkdir -p to-release
+          if test "$IMAGE_SIZE" -lt "2000000000"; then 
+            split -b 2GiB ./guix-installer-$RELEASE_TAG.tar.gz "guix-installer-$RELEASE_TAG.tar.gz-part-"
+            mv guix-installer-$RELEASE_TAG.tar.gz-part-* to-release/
+          else
+            mv ./guix-installer-$RELEASE_TAG.tar.gz to-release/
+          fi
       - uses: actions/cache/save@v3
         if: always()
         with:
@@ -90,7 +99,7 @@ jobs:
           name: Guix Installer - ${{ env.RELEASE_TAG }}
           tag_name: v${{ env.RELEASE_TAG }}
           body_path: release-notes.md
-          files: guix-installer-${{ env.RELEASE_TAG }}.tar.gz-part-*
+          files: to-release/*
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITHUB_REPOSITORY: SystemCrafters/guix-installer
+          GITHUB_REPOSITORY: SohamG/guix-installer

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -70,6 +70,8 @@ jobs:
           export RELEASE_TAG=$(date +"%Y%m%d%H%M")
           echo "RELEASE_TAG=$RELEASE_TAG" >> $GITHUB_ENV
           cp $image ./guix-installer-$RELEASE_TAG.iso
+          tar czvf guix-installer-$RELEASE_TAG.tar.gz ./guix-installer-$RELEASE_TAG.iso
+          split -b 2GiB ./guix-installer-$RELEASE_TAG.tar.gz "guix-installer-$RELEASE_TAG.tar.gz-part-"
       - uses: actions/cache/save@v3
         if: always()
         with:
@@ -88,7 +90,7 @@ jobs:
           name: Guix Installer - ${{ env.RELEASE_TAG }}
           tag_name: v${{ env.RELEASE_TAG }}
           body_path: release-notes.md
-          files: guix-installer-${{ env.RELEASE_TAG }}.iso
+          files: guix-installer-${{ env.RELEASE_TAG }}.tar.gz-part-*
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: SystemCrafters/guix-installer

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -102,4 +102,4 @@ jobs:
           files: to-release/*
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITHUB_REPOSITORY: SohamG/guix-installer
+          GITHUB_REPOSITORY: SystemCrafters/guix-installer

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -75,7 +75,7 @@ jobs:
           # Github limits single files to 2GiB in releases.
           IMAGE_SIZE=$(stat -c %s ./guix-installer-$RELEASE_TAG.tar.gz)
           mkdir -p to-release
-          if test "$IMAGE_SIZE" -lt "2000000000"; then 
+          if test "$IMAGE_SIZE" -ge "2000000000"; then 
             split -b 2GiB ./guix-installer-$RELEASE_TAG.tar.gz "guix-installer-$RELEASE_TAG.tar.gz-part-"
             mv guix-installer-$RELEASE_TAG.tar.gz-part-* to-release/
           else


### PR DESCRIPTION
Work around 2Gib release file limit as follows:

1) Tar gz the image
2) if the tar.gz is larger than 2GiB, use the linux `split` command, make multiple files. Add all files to release.
3) Otherwise, add tar.gz to release.

In case of 2, user would have to cat all the files in order to a single targz before extracting. We can provide a shell script for this.

A longer term solution is to host the ISO on some cloud object storage.
Resolve #35 