### PR TITLE
WIP: fixes to unbreak the build

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -128,6 +128,7 @@ jobs:
           tag_name: v${{ env.RELEASE_TAG }}
           body_path: release-notes.md
           files: guix-installer-${{ env.RELEASE_TAG }}.iso
+          fail_on_unmatched_files: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: SystemCrafters/guix-installer

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -16,6 +16,47 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+      - name: Aggressive cleanup
+        run: |
+          df -h
+
+          # Remove Java (JDKs)
+          sudo rm -rf /usr/lib/jvm
+
+          # Remove .NET SDKs
+          sudo rm -rf /usr/share/dotnet
+
+          # Remove Swift toolchain
+          sudo rm -rf /usr/share/swift
+
+          # Remove Haskell (GHC)
+          sudo rm -rf /usr/local/.ghcup
+
+          # Remove Julia
+          sudo rm -rf /usr/local/julia*
+
+          # Remove Android SDKs
+          sudo rm -rf /usr/local/lib/android
+
+          # Remove Chromium (optional if not using for browser tests)
+          sudo rm -rf /usr/local/share/chromium
+
+          # Remove Microsoft/Edge and Google Chrome builds
+          sudo rm -rf /opt/microsoft /opt/google
+
+          # Remove Azure CLI
+          sudo rm -rf /opt/az
+
+          # Remove PowerShell
+          sudo rm -rf /usr/local/share/powershell
+
+          # Remove CodeQL and other toolcaches
+          sudo rm -rf /opt/hostedtoolcache
+
+          docker system prune -af || true
+          docker builder prune -af || true
+          df -h
+
       - name: Git checkout
         uses: actions/checkout@v4
       - name: Guix cache

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -28,7 +28,7 @@ jobs:
             guix-cache-
 
       - name: Install Guix
-        uses: PromyLOPh/guix-install-action@v1.5
+        uses: PromyLOPh/guix-install-action@v1.6
         with:
           channels: |
             (cons* (channel

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -16,45 +16,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: Aggressive cleanup
+      - name: Cleanup
         run: |
           df -h
-
-          # Remove Java (JDKs)
-          sudo rm -rf /usr/lib/jvm
-
-          # Remove .NET SDKs
-          sudo rm -rf /usr/share/dotnet
-
-          # Remove Swift toolchain
-          sudo rm -rf /usr/share/swift
-
-          # Remove Haskell (GHC)
-          sudo rm -rf /usr/local/.ghcup
-
-          # Remove Julia
-          sudo rm -rf /usr/local/julia*
-
-          # Remove Android SDKs
-          sudo rm -rf /usr/local/lib/android
-
-          # Remove Chromium (optional if not using for browser tests)
-          sudo rm -rf /usr/local/share/chromium
-
-          # Remove Microsoft/Edge and Google Chrome builds
-          sudo rm -rf /opt/microsoft /opt/google
-
-          # Remove Azure CLI
-          sudo rm -rf /opt/az
-
-          # Remove PowerShell
-          sudo rm -rf /usr/local/share/powershell
-
-          # Remove CodeQL and other toolcaches
-          sudo rm -rf /opt/hostedtoolcache
-
-          docker system prune -af || true
-          docker builder prune -af || true
+          sudo rm -rf /opt /usr/lib/jvm /usr/local /usr/share
           df -h
 
       - name: Git checkout

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -16,10 +16,43 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: Cleanup
+      - name: Aggressive cleanup
         run: |
           df -h
-          sudo rm -rf /opt /usr/lib/jvm /usr/local /usr/share
+
+          # Remove Java (JDKs)
+          sudo rm -rf /usr/lib/jvm
+
+          # Remove .NET SDKs
+          sudo rm -rf /usr/share/dotnet
+
+          # Remove Swift toolchain
+          sudo rm -rf /usr/share/swift
+
+          # Remove Haskell (GHC)
+          sudo rm -rf /usr/local/.ghcup
+
+          # Remove Julia
+          sudo rm -rf /usr/local/julia*
+
+          # Remove Android SDKs
+          sudo rm -rf /usr/local/lib/android
+
+          # Remove Chromium (optional if not using for browser tests)
+          sudo rm -rf /usr/local/share/chromium
+
+          # Remove Microsoft/Edge and Google Chrome builds
+          sudo rm -rf /opt/microsoft /opt/google
+
+          # Remove Azure CLI
+          sudo rm -rf /opt/az
+
+          # Remove PowerShell
+          sudo rm -rf /usr/local/share/powershell
+
+          # Remove CodeQL and other toolcaches
+          sudo rm -rf /opt/hostedtoolcache
+
           df -h
 
       - name: Git checkout

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -64,7 +64,7 @@ jobs:
           guix time-machine -C ./guix/base-channels.scm -- describe -f channels > ./guix/channels.scm
           
           # Build the image
-          image=$(guix time-machine -C ./guix/channels.scm -- system image -t iso9660 ./guix/installer.scm)
+          image=$(guix time-machine -C ./guix/channels.scm -- system -v 3 image -t iso9660 ./guix/installer.scm)
 
           # Copy the image to the local folder with a better name
           export RELEASE_TAG=$(date +"%Y%m%d%H%M")

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -103,7 +103,7 @@ jobs:
           guix time-machine -C ./guix/base-channels.scm -- describe -f channels > ./guix/channels.scm
           
           # Build the image
-          image=$(guix time-machine -C ./guix/channels.scm -- system -v 3 image -t iso9660 ./guix/installer.scm)
+          image=$(guix time-machine -C ./guix/channels.scm -- system image -t iso9660 ./guix/installer.scm)
 
           # Copy the image to the local folder with a better name
           export RELEASE_TAG=$(date +"%Y%m%d%H%M")

--- a/guix/installer.scm
+++ b/guix/installer.scm
@@ -61,7 +61,14 @@
   (operating-system
     (inherit installation-os)
     (kernel linux)
-    (firmware (list amdgpu-firmware))
+    (firmware (list
+	       ;; amdgpu-firmware
+	       atheros-firmware
+	       broadcom-sta
+	       ;; i915-firmware
+	       iwlwifi-firmware
+	       mediatek-firmware
+	       realtek-firmware))
 
     ;; Add the 'net.ifnames' argument to prevent network interfaces
     ;; from having really long names.  This can cause an issue with

--- a/guix/installer.scm
+++ b/guix/installer.scm
@@ -61,7 +61,7 @@
   (operating-system
     (inherit installation-os)
     (kernel linux)
-    (firmware (list linux-firmware))
+    (firmware (list amdgpu-firmware))
 
     ;; Add the 'net.ifnames' argument to prevent network interfaces
     ;; from having really long names.  This can cause an issue with

--- a/guix/installer.scm
+++ b/guix/installer.scm
@@ -62,13 +62,14 @@
     (inherit installation-os)
     (kernel linux)
     (firmware (list
-	       ;; amdgpu-firmware
-	       atheros-firmware
-	       broadcom-sta
-	       ;; i915-firmware
-	       iwlwifi-firmware
-	       mediatek-firmware
-	       realtek-firmware))
+               amdgpu-firmware
+               ;; atheros-firmware
+               ;; broadcom-sta
+               ;; i915-firmware
+               ;; iwlwifi-firmware
+               ;; mediatek-firmware
+               ;; realtek-firmware
+	       ))
 
     ;; Add the 'net.ifnames' argument to prevent network interfaces
     ;; from having really long names.  This can cause an issue with


### PR DESCRIPTION
Hi David,

First of all, I want to give a big thank you for your YouTube videos!

I made some improvements to the CI pipeline, but there is still something wrong with the ISO

It includes gcc and other large components that probably do not need to be included. This way the closure size is somewhat reduced.

I was able to build and install from an ISO with just the amdgpu firmware.

I added the aggressive cleaning of system image because the build process was also running out of space, and these components are not needed.

I hope someone can make use of these changes, if they are interested to install from a Nonguix ISO.